### PR TITLE
feat(auth-test): add unit test for auth usecase

### DIFF
--- a/domain/exception/error.go
+++ b/domain/exception/error.go
@@ -17,6 +17,7 @@ var (
 	ErrPermissionDenied     = errors.New("no permssion")
 	ErrParamsMissing        = errors.New("some params are missing")
 	ErrCouldNotUpdateStatus = errors.New("could not update status yet")
+	ErrJWTSecretIsEmpty     = errors.New("jwt secret is empty")
 
 	ErrProductRequestAlreadyPaid = errors.New("product request already paid")
 

--- a/usecase/auth.go
+++ b/usecase/auth.go
@@ -39,6 +39,10 @@ func NewAuthUsecase(userRepo repository.UserRepository, oauthRepoFactory *reposi
 }
 
 func (a *authService) GetJWT(user *domain.User) (string, error) {
+	if a.cfg.JWTSecret == "" {
+		return "", exception.ErrJWTSecretIsEmpty
+	}
+
 	expiredAt := time.Now().Add(time.Hour * 24) // 1 day
 	claims := jwt.MapClaims{
 		"id":          user.ID,
@@ -121,7 +125,7 @@ func (a *authService) Register(ctx context.Context, req dto.RegisterUserRequestD
 		Password:   &req.Password,
 	})
 	if createErr != nil {
-		return err
+		return createErr
 	}
 
 	return nil

--- a/usecase/auth_test.go
+++ b/usecase/auth_test.go
@@ -1,0 +1,192 @@
+package usecase_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt"
+	"github.com/hewpao/hewpao-backend/config"
+	"github.com/hewpao/hewpao-backend/domain"
+	"github.com/hewpao/hewpao-backend/domain/exception"
+	"github.com/hewpao/hewpao-backend/dto"
+	"github.com/hewpao/hewpao-backend/usecase"
+	"github.com/hewpao/hewpao-backend/usecase/test/mock_repos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestAuthUsecase_GetJWT(t *testing.T) {
+	mockUserRepo := new(mock_repos.MockUserRepo)
+	cfg := &config.Config{JWTSecret: "mysecret"}
+	ctx := context.Background()
+
+	authService := usecase.NewAuthUsecase(mockUserRepo, nil, cfg, nil, ctx)
+
+	t.Run("Success", func(t *testing.T) {
+		user := &domain.User{
+			ID:         "user123",
+			Email:      "user@example.com",
+			Name:       "John",
+			Surname:    "Doe",
+			IsVerified: true,
+		}
+
+		jwtToken, err := authService.GetJWT(user)
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, jwtToken)
+
+		parsedToken, err := jwt.Parse(jwtToken, func(token *jwt.Token) (interface{}, error) {
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+			}
+			return []byte(cfg.JWTSecret), nil
+		})
+
+		assert.NoError(t, err)
+
+		claims, ok := parsedToken.Claims.(jwt.MapClaims)
+		assert.True(t, ok, "Token claims should be of type jwt.MapClaims")
+		assert.Equal(t, user.ID, claims["id"])
+		assert.Equal(t, user.Email, claims["email"])
+		assert.Equal(t, user.Name, claims["name"])
+		assert.Equal(t, user.Surname, claims["surname"])
+		assert.Equal(t, true, claims["is_verified"])
+
+		expTime := time.Unix(int64(claims["exp"].(float64)), 0)
+
+		assert.True(t, expTime.After(time.Now()), "JWT expiration time should be in the future")
+
+		mockUserRepo.AssertExpectations(t)
+	})
+
+	t.Run("Error_SigningFailed", func(t *testing.T) {
+		user := &domain.User{
+			ID: "user123",
+		}
+
+		cfg.JWTSecret = ""
+
+		jwtToken, err := authService.GetJWT(user)
+
+		assert.Error(t, err)
+		assert.Empty(t, jwtToken)
+
+		mockUserRepo.AssertExpectations(t)
+	})
+}
+
+func TestAuthUsecase_LoginWithCredentials(t *testing.T) {
+	mockUserRepo := new(mock_repos.MockUserRepo)
+	cfg := &config.Config{JWTSecret: "mysecret"}
+	ctx := context.Background()
+
+	authService := usecase.NewAuthUsecase(mockUserRepo, nil, cfg, nil, ctx)
+
+	t.Run("Success", func(t *testing.T) {
+		req := dto.LoginWithCredentialsRequestDTO{
+			Email:    "user@example.com",
+			Password: "test_password",
+		}
+
+		userPassword := "$argon2id$v=19$m=65536,t=3,p=4$FXmLBDy38gqYZbnq93O3dQ$nGnJi8zr0nrWAcx1kXBQA62pBbKvWygShzVCjexi7RI"
+
+		expectedUser := &domain.User{
+			ID:         "user123",
+			Email:      "user@example.com",
+			Password:   &userPassword,
+			IsVerified: true,
+		}
+
+		mockUserRepo.On("FindByEmail", ctx, req.Email).Return(expectedUser, nil)
+
+		resp, err := authService.LoginWithCredentials(ctx, req)
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, resp.AccessToken)
+		mockUserRepo.AssertExpectations(t)
+	})
+
+	t.Run("Error_UserNotFound", func(t *testing.T) {
+		req := dto.LoginWithCredentialsRequestDTO{
+			Email:    "user@example.com",
+			Password: "password123",
+		}
+
+		mockUserRepo.On("FindByEmail", ctx, req.Email).Return(nil, exception.ErrUserNotFound)
+
+		resp, err := authService.LoginWithCredentials(ctx, req)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		mockUserRepo.AssertExpectations(t)
+	})
+
+	t.Run("Error_InvalidPassword", func(t *testing.T) {
+		req := dto.LoginWithCredentialsRequestDTO{
+			Email:    "user@example.com",
+			Password: "wrongpassword",
+		}
+
+		userPassword := "hashedpassword123"
+
+		expectedUser := &domain.User{
+			ID:         "user123",
+			Email:      "user@example.com",
+			Password:   &userPassword, // Assume hashed password is used
+			IsVerified: true,
+		}
+
+		mockUserRepo.On("FindByEmail", ctx, req.Email).Return(expectedUser, nil)
+
+		resp, err := authService.LoginWithCredentials(ctx, req)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		mockUserRepo.AssertExpectations(t)
+	})
+}
+
+func TestAuthUsecase_Register(t *testing.T) {
+	mockUserRepo := new(mock_repos.MockUserRepo)
+	cfg := &config.Config{}
+	ctx := context.Background()
+
+	authService := usecase.NewAuthUsecase(mockUserRepo, nil, cfg, nil, ctx)
+
+	t.Run("Success", func(t *testing.T) {
+		req := dto.RegisterUserRequestDTO{
+			Email:      "newuser@example.com",
+			Password:   "password123",
+			Name:       "John Doe",
+			MiddleName: nil,
+			Surname:    "Test",
+		}
+
+		mockUserRepo.On("FindByEmail", ctx, req.Email).Return(nil, exception.ErrUserNotFound)
+		mockUserRepo.On("Create", ctx, mock.Anything).Return(nil)
+
+		err := authService.Register(ctx, req)
+
+		assert.NoError(t, err)
+		mockUserRepo.AssertExpectations(t)
+	})
+
+	t.Run("Error_UserExists", func(t *testing.T) {
+		req := dto.RegisterUserRequestDTO{
+			Email:    "existinguser@example.com",
+			Password: "password123",
+			Name:     "John Doe",
+		}
+
+		mockUserRepo.On("FindByEmail", ctx, req.Email).Return(&domain.User{Email: "existinguser@example.com"}, nil)
+
+		err := authService.Register(ctx, req)
+
+		assert.Error(t, err)
+		assert.Equal(t, exception.ErrUserAlreadyExist, err)
+		mockUserRepo.AssertExpectations(t)
+	})
+}

--- a/usecase/test/mock_repos/user.go
+++ b/usecase/test/mock_repos/user.go
@@ -19,7 +19,10 @@ func (mu *MockUserRepo) FindByID(ctx context.Context, id string) (*domain.User, 
 
 func (mu *MockUserRepo) FindByEmail(ctx context.Context, email string) (*domain.User, error) {
 	args := mu.Called(ctx, email)
-	return args.Get(0).(*domain.User), args.Error(1)
+	if user, ok := args.Get(0).(*domain.User); ok {
+		return user, args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 func (mu *MockUserRepo) Create(ctx context.Context, req dto.CreateUserDTO) error {


### PR DESCRIPTION
This pull request includes several updates to the authentication use case, error handling, and testing in the codebase. The most important changes include the addition of a new error type, updates to the authentication service to handle empty JWT secrets, and the introduction of comprehensive tests for the authentication use case.

### Error Handling Improvements:
* Added a new error type `ErrJWTSecretIsEmpty` to handle cases where the JWT secret is not provided in the configuration (`domain/exception/error.go`).
* Updated the `GetJWT` function in the `authService` to return the new error when the JWT secret is empty (`usecase/auth.go`).

### Authentication Use Case Enhancements:
* Corrected the error handling in the `Register` function of the `authService` to return the correct error variable (`usecase/auth.go`).

### Testing Additions:
* Added comprehensive tests for the `authService` covering `GetJWT`, `LoginWithCredentials`, and `Register` functions (`usecase/auth_test.go`).

### Mock Repository Improvements:
* Improved the `FindByEmail` function in the mock user repository to handle cases where the returned user is nil (`usecase/test/mock_repos/user.go`).