### PR TITLE
feat(verification-test): add unit test for verification usecase

### DIFF
--- a/repository/ekyc.go
+++ b/repository/ekyc.go
@@ -11,19 +11,24 @@ type EKYCRepository interface {
 	Verify(file *multipart.FileHeader) (*dto.EKYCResponseDTO, error)
 }
 
-type EKYCRepositoryFactory struct {
+type EKYCRepositoryFactory interface {
+	Register(provider string, repo EKYCRepository)
+	GetRepository(provider string) (EKYCRepository, error)
+}
+
+type eKYCRepositoryFactory struct {
 	repos map[string]EKYCRepository
 }
 
 func NewEKYCRepositoryFactory() EKYCRepositoryFactory {
-	return EKYCRepositoryFactory{repos: make(map[string]EKYCRepository)}
+	return &eKYCRepositoryFactory{repos: make(map[string]EKYCRepository)}
 }
 
-func (f *EKYCRepositoryFactory) Register(provider string, repo EKYCRepository) {
+func (f *eKYCRepositoryFactory) Register(provider string, repo EKYCRepository) {
 	f.repos[provider] = repo
 }
 
-func (f *EKYCRepositoryFactory) GetRepository(provider string) (EKYCRepository, error) {
+func (f *eKYCRepositoryFactory) GetRepository(provider string) (EKYCRepository, error) {
 	repo, exists := f.repos[provider]
 	if !exists {
 		return nil, errors.New("unsupported ekyc provider")

--- a/usecase/test/mock_repos/ekyc.go
+++ b/usecase/test/mock_repos/ekyc.go
@@ -4,6 +4,7 @@ import (
 	"mime/multipart"
 
 	"github.com/hewpao/hewpao-backend/dto"
+	"github.com/hewpao/hewpao-backend/repository"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -14,4 +15,20 @@ type MockEKYCRepository struct {
 func (m *MockEKYCRepository) Verify(file *multipart.FileHeader) (*dto.EKYCResponseDTO, error) {
 	args := m.Called(file)
 	return args.Get(0).(*dto.EKYCResponseDTO), args.Error(1)
+}
+
+type MockEKYCRepositoryFactory struct {
+	mock.Mock
+}
+
+func (m *MockEKYCRepositoryFactory) Register(provider string, repo repository.EKYCRepository) {
+	m.Called(provider, repo)
+}
+
+func (f *MockEKYCRepositoryFactory) GetRepository(provider string) (repository.EKYCRepository, error) {
+	args := f.Called(provider)
+	if repo, ok := args.Get(0).(repository.EKYCRepository); ok {
+		return repo, args.Error(1)
+	}
+	return nil, args.Error(1)
 }

--- a/usecase/verification_test.go
+++ b/usecase/verification_test.go
@@ -1,0 +1,95 @@
+package usecase_test
+
+import (
+	"context"
+	"io"
+	"mime/multipart"
+	"testing"
+
+	"github.com/hewpao/hewpao-backend/config"
+	"github.com/hewpao/hewpao-backend/domain"
+	"github.com/hewpao/hewpao-backend/dto"
+	"github.com/hewpao/hewpao-backend/types"
+	"github.com/hewpao/hewpao-backend/usecase"
+	"github.com/hewpao/hewpao-backend/usecase/test/mock_repos"
+	"github.com/minio/minio-go/v7"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestVerifyWithKYC(t *testing.T) {
+	ctx := context.Background()
+	mockMinioRepo := new(mock_repos.MockS3Repository)
+	mockUserRepo := new(mock_repos.MockUserRepo)
+	mockVerificationRepo := new(mock_repos.MockVerificationRepository)
+	mockEKYCFactory := new(mock_repos.MockEKYCRepositoryFactory)
+	mockEKYCRepo := new(mock_repos.MockEKYCRepository)
+
+	cfg := config.Config{}
+	service := usecase.NewVerificationService(mockMinioRepo, ctx, cfg, mockUserRepo, mockVerificationRepo, mockEKYCFactory)
+
+	userID := "12345"
+	provider := "mockProvider"
+	fileHeader := &multipart.FileHeader{Filename: "test.jpg", Size: 1024}
+	reader := io.NopCloser(nil)
+
+	mockUserRepo.On("FindByID", ctx, userID).Return(&domain.User{ID: userID}, nil)
+	mockMinioRepo.On("UploadFile", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything, "verification-images").Return(minio.UploadInfo{}, nil)
+	mockEKYCFactory.On("GetRepository", provider).Return(mockEKYCRepo, nil)
+	mockEKYCRepo.On("Verify", fileHeader).Return(&dto.EKYCResponseDTO{IDNumber: "123456789"}, nil)
+	mockVerificationRepo.On("Create", mock.Anything).Return(nil)
+
+	err := service.VerifyWithKYC(reader, fileHeader, userID, provider)
+	assert.NoError(t, err)
+	mockUserRepo.AssertExpectations(t)
+	mockMinioRepo.AssertExpectations(t)
+	mockEKYCFactory.AssertExpectations(t)
+	mockEKYCRepo.AssertExpectations(t)
+	mockVerificationRepo.AssertExpectations(t)
+}
+
+func TestGetVerificationInfo(t *testing.T) {
+	ctx := context.Background()
+	mockMinioRepo := new(mock_repos.MockS3Repository)
+	mockUserRepo := new(mock_repos.MockUserRepo)
+	mockVerificationRepo := new(mock_repos.MockVerificationRepository)
+	cfg := config.Config{S3Expiration: "2h30m"}
+	service := usecase.NewVerificationService(mockMinioRepo, ctx, cfg, mockUserRepo, mockVerificationRepo, &mock_repos.MockEKYCRepositoryFactory{})
+
+	instructorEmail := "admin@example.com"
+	verificationID := uint(1)
+	verification := &domain.Verification{CardImage: new(string)}
+	*verification.CardImage = "hewpao-s3/test_image.png"
+
+	mockUserRepo.On("FindByEmail", ctx, instructorEmail).Return(&domain.User{Role: types.Admin}, nil)
+	mockVerificationRepo.On("FindByID", verificationID).Return(verification, nil)
+	mockMinioRepo.On("GetSignedURL", ctx, mock.Anything, mock.Anything, mock.Anything).Return("https://example.com/bucket/key", nil)
+
+	var info domain.Verification
+	err := service.GetVerificationInfo(instructorEmail, &info, verificationID)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.com/bucket/key", *info.CardImage)
+	mockUserRepo.AssertExpectations(t)
+	mockVerificationRepo.AssertExpectations(t)
+	mockMinioRepo.AssertExpectations(t)
+}
+
+func TestUpdateIsVerified(t *testing.T) {
+	ctx := context.Background()
+	mockUserRepo := new(mock_repos.MockUserRepo)
+	cfg := config.Config{}
+	mockVerificationRepo := new(mock_repos.MockVerificationRepository)
+	service := usecase.NewVerificationService(nil, ctx, cfg, mockUserRepo, mockVerificationRepo, &mock_repos.MockEKYCRepositoryFactory{})
+
+	userEmail := "user@example.com"
+	instructorEmail := "admin@example.com"
+	req := &dto.UpdateUserVerificationDTO{Isverified: true}
+
+	mockUserRepo.On("FindByEmail", ctx, instructorEmail).Return(&domain.User{Role: types.Admin}, nil)
+	mockUserRepo.On("FindByEmail", ctx, userEmail).Return(&domain.User{}, nil)
+	mockUserRepo.On("UpdateVerification", ctx, mock.Anything).Return(nil)
+
+	err := service.UpdateIsVerified(req, userEmail, instructorEmail)
+	assert.NoError(t, err)
+	mockUserRepo.AssertExpectations(t)
+}


### PR DESCRIPTION
This pull request introduces significant changes to the `ekyc` repository and its related test cases. The changes primarily focus on refactoring the `EKYCRepositoryFactory`, adding mock implementations for testing, and creating new test cases for the verification service.

Refactoring and Interface Changes:

* [`repository/ekyc.go`](diffhunk://#diff-931fa1e5bc67f9908abfd9fb38a6649b5a2a1031f5a15b8328198884ecc85547L14-R31): Refactored `EKYCRepositoryFactory` to be an interface and implemented it as `eKYCRepositoryFactory`. The factory now includes `Register` and `GetRepository` methods.

Testing Enhancements:

* [`usecase/test/mock_repos/ekyc.go`](diffhunk://#diff-b95a6cdd2252e5b75077bd0e46a6bdc93ee893c40d91caad6b99feab347046b9R19-R34): Added a new mock implementation `MockEKYCRepositoryFactory` to facilitate testing of the `EKYCRepositoryFactory` interface.
* [`usecase/verification_test.go`](diffhunk://#diff-e99acb0f41aa3eea57c96193b81b9b269774bf293fd8ec87213faa3b71f02667R1-R95): Added comprehensive test cases for the verification service, including `TestVerifyWithKYC`, `TestGetVerificationInfo`, and `TestUpdateIsVerified`. These tests cover various aspects of the verification process, ensuring the correctness of interactions with the repository and the service logic.

Dependency Updates:

* [`usecase/test/mock_repos/ekyc.go`](diffhunk://#diff-b95a6cdd2252e5b75077bd0e46a6bdc93ee893c40d91caad6b99feab347046b9R7): Imported the `repository` package to use the `EKYCRepository` interface in the mock implementations.